### PR TITLE
Open generic editor closes # 4

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.0
+current_version = 0.1.1
 
 [bumpversion:file:pyproject.toml]
 search = version = "{current_version}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,9 +42,9 @@ jobs:
         brew unlink bats
         brew install --force bats-core
       if: matrix.os == 'macOS-latest'
-    - name: ubuntu install bats
-      run: |
-        brew install bats
+    # - name: ubuntu install bats
+    #   run: |
+    #     brew install bats
     - name: Install Poetry
       run: |
         python -m pip install --upgrade pip
@@ -55,4 +55,5 @@ jobs:
     - name: Test
       run: |
         # bats -r does not follow symlinks, pass paths explicitly using find
+        # test_helper.bash setUp function handles creating the project under test using cookiecutter
         bats $(find ./tests -name '*.bats' | sort)

--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ Provides the following functions
     1. pull master
     1. create new branch
     1. create new issue dir
-    1. open in vscode
+    1. open in editor
 1. `$your_project_new_retro`
     1. create retro from template
-    1. open in vscode
+    1. open in editor
 
 # Development
 See [dev.md](./dev.md)

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -2,5 +2,6 @@
   "project_name": "alphabet",
   "jira_code": "ABC",
   "repo_dir": "$HOME/Workspace/example",
-  "base_dir": "$HOME/Documents/notes/rtls"
+  "base_dir": "$HOME/Documents/notes/rtls",
+  "editor": "code"
 }

--- a/dev.md
+++ b/dev.md
@@ -8,6 +8,9 @@ poetry run cookiecutter .
 # Tests
 ```bash
 bats $(find ./tests -name '*.bats' | sort)
+
+# alias for the above, can also be used
+poetry run task tests
 ```
 
 # Version management

--- a/dev.md
+++ b/dev.md
@@ -13,6 +13,18 @@ bats $(find ./tests -name '*.bats' | sort)
 poetry run task tests
 ```
 
+### Debugging tests
+```bat
+# https://github.com/sstephenson/bats/issues/191
+# note test must fail to see output, which is why we need [ "$status" -eq 0 ]
+@test 'test-a' {
+  run bash -c 'echo ERROR; false'
+  echo "status = ${status}"
+  echo "output = ${output}"
+  [ "$status" -eq 0 ]
+}
+```
+
 # Version management
 ```bash
 # pass args e.g. patch, minor, major, choose to commit changes or not

--- a/poetry.lock
+++ b/poetry.lock
@@ -54,6 +54,14 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
+name = "colorama"
+version = "0.4.4"
+description = "Cross-platform colored terminal text."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
 name = "cookiecutter"
 version = "1.7.2"
 description = "A command-line utility that creates projects from project templates, e.g. creating a Python package project from a Python package project template."
@@ -115,12 +123,31 @@ optional = false
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
 
 [[package]]
+name = "mslex"
+version = "0.3.0"
+description = "shlex for windows"
+category = "dev"
+optional = false
+python-versions = ">=3.5"
+
+[[package]]
 name = "poyo"
 version = "0.5.0"
 description = "A lightweight YAML Parser for Python. 🐓"
 category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "psutil"
+version = "5.8.0"
+description = "Cross-platform lib for process and system monitoring in Python."
+category = "dev"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[package.extras]
+test = ["ipaddress", "mock", "unittest2", "enum34", "pywin32", "wmi"]
 
 [[package]]
 name = "python-dateutil"
@@ -174,12 +201,34 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
+name = "taskipy"
+version = "1.8.1"
+description = "tasks runner for python projects"
+category = "dev"
+optional = false
+python-versions = ">=3.6,<4.0"
+
+[package.dependencies]
+colorama = ">=0.4.4,<0.5.0"
+mslex = ">=0.3.0,<0.4.0"
+psutil = ">=5.7.2,<6.0.0"
+toml = ">=0.10.0,<0.11.0"
+
+[[package]]
 name = "text-unidecode"
 version = "1.3"
 description = "The most basic Text::Unidecode port"
 category = "main"
 optional = false
 python-versions = "*"
+
+[[package]]
+name = "toml"
+version = "0.10.2"
+description = "Python Library for Tom's Obvious, Minimal Language"
+category = "dev"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "typing-extensions"
@@ -205,7 +254,7 @@ brotli = ["brotlipy (>=0.6.0)"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "e65ef2104d3a123c4f7e254389b59fbb3dd0328f2519de6379cc301a7fd61166"
+content-hash = "add26eab582154f2425482c46e7e59a31e3000f461139e28664b47cf1adc5943"
 
 [metadata.files]
 arrow = [
@@ -231,6 +280,10 @@ chardet = [
 click = [
     {file = "click-7.1.2-py2.py3-none-any.whl", hash = "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"},
     {file = "click-7.1.2.tar.gz", hash = "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a"},
+]
+colorama = [
+    {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
+    {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
 cookiecutter = [
     {file = "cookiecutter-1.7.2-py2.py3-none-any.whl", hash = "sha256:430eb882d028afb6102c084bab6cf41f6559a77ce9b18dc6802e3bc0cc5f4a30"},
@@ -283,9 +336,43 @@ markupsafe = [
     {file = "MarkupSafe-1.1.1-cp38-cp38-win_amd64.whl", hash = "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be"},
     {file = "MarkupSafe-1.1.1.tar.gz", hash = "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b"},
 ]
+mslex = [
+    {file = "mslex-0.3.0-py2.py3-none-any.whl", hash = "sha256:380cb14abf8fabf40e56df5c8b21a6d533dc5cbdcfe42406bbf08dda8f42e42a"},
+    {file = "mslex-0.3.0.tar.gz", hash = "sha256:4a1ac3f25025cad78ad2fe499dd16d42759f7a3801645399cce5c404415daa97"},
+]
 poyo = [
     {file = "poyo-0.5.0-py2.py3-none-any.whl", hash = "sha256:3e2ca8e33fdc3c411cd101ca395668395dd5dc7ac775b8e809e3def9f9fe041a"},
     {file = "poyo-0.5.0.tar.gz", hash = "sha256:e26956aa780c45f011ca9886f044590e2d8fd8b61db7b1c1cf4e0869f48ed4dd"},
+]
+psutil = [
+    {file = "psutil-5.8.0-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:0066a82f7b1b37d334e68697faba68e5ad5e858279fd6351c8ca6024e8d6ba64"},
+    {file = "psutil-5.8.0-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:0ae6f386d8d297177fd288be6e8d1afc05966878704dad9847719650e44fc49c"},
+    {file = "psutil-5.8.0-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:12d844996d6c2b1d3881cfa6fa201fd635971869a9da945cf6756105af73d2df"},
+    {file = "psutil-5.8.0-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:02b8292609b1f7fcb34173b25e48d0da8667bc85f81d7476584d889c6e0f2131"},
+    {file = "psutil-5.8.0-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:6ffe81843131ee0ffa02c317186ed1e759a145267d54fdef1bc4ea5f5931ab60"},
+    {file = "psutil-5.8.0-cp27-none-win32.whl", hash = "sha256:ea313bb02e5e25224e518e4352af4bf5e062755160f77e4b1767dd5ccb65f876"},
+    {file = "psutil-5.8.0-cp27-none-win_amd64.whl", hash = "sha256:5da29e394bdedd9144c7331192e20c1f79283fb03b06e6abd3a8ae45ffecee65"},
+    {file = "psutil-5.8.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:74fb2557d1430fff18ff0d72613c5ca30c45cdbfcddd6a5773e9fc1fe9364be8"},
+    {file = "psutil-5.8.0-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:74f2d0be88db96ada78756cb3a3e1b107ce8ab79f65aa885f76d7664e56928f6"},
+    {file = "psutil-5.8.0-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:99de3e8739258b3c3e8669cb9757c9a861b2a25ad0955f8e53ac662d66de61ac"},
+    {file = "psutil-5.8.0-cp36-cp36m-win32.whl", hash = "sha256:36b3b6c9e2a34b7d7fbae330a85bf72c30b1c827a4366a07443fc4b6270449e2"},
+    {file = "psutil-5.8.0-cp36-cp36m-win_amd64.whl", hash = "sha256:52de075468cd394ac98c66f9ca33b2f54ae1d9bff1ef6b67a212ee8f639ec06d"},
+    {file = "psutil-5.8.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c6a5fd10ce6b6344e616cf01cc5b849fa8103fbb5ba507b6b2dee4c11e84c935"},
+    {file = "psutil-5.8.0-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:61f05864b42fedc0771d6d8e49c35f07efd209ade09a5afe6a5059e7bb7bf83d"},
+    {file = "psutil-5.8.0-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:0dd4465a039d343925cdc29023bb6960ccf4e74a65ad53e768403746a9207023"},
+    {file = "psutil-5.8.0-cp37-cp37m-win32.whl", hash = "sha256:1bff0d07e76114ec24ee32e7f7f8d0c4b0514b3fae93e3d2aaafd65d22502394"},
+    {file = "psutil-5.8.0-cp37-cp37m-win_amd64.whl", hash = "sha256:fcc01e900c1d7bee2a37e5d6e4f9194760a93597c97fee89c4ae51701de03563"},
+    {file = "psutil-5.8.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6223d07a1ae93f86451d0198a0c361032c4c93ebd4bf6d25e2fb3edfad9571ef"},
+    {file = "psutil-5.8.0-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:d225cd8319aa1d3c85bf195c4e07d17d3cd68636b8fc97e6cf198f782f99af28"},
+    {file = "psutil-5.8.0-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:28ff7c95293ae74bf1ca1a79e8805fcde005c18a122ca983abf676ea3466362b"},
+    {file = "psutil-5.8.0-cp38-cp38-win32.whl", hash = "sha256:ce8b867423291cb65cfc6d9c4955ee9bfc1e21fe03bb50e177f2b957f1c2469d"},
+    {file = "psutil-5.8.0-cp38-cp38-win_amd64.whl", hash = "sha256:90f31c34d25b1b3ed6c40cdd34ff122b1887a825297c017e4cbd6796dd8b672d"},
+    {file = "psutil-5.8.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6323d5d845c2785efb20aded4726636546b26d3b577aded22492908f7c1bdda7"},
+    {file = "psutil-5.8.0-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:245b5509968ac0bd179287d91210cd3f37add77dad385ef238b275bad35fa1c4"},
+    {file = "psutil-5.8.0-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:90d4091c2d30ddd0a03e0b97e6a33a48628469b99585e2ad6bf21f17423b112b"},
+    {file = "psutil-5.8.0-cp39-cp39-win32.whl", hash = "sha256:ea372bcc129394485824ae3e3ddabe67dc0b118d262c568b4d2602a7070afdb0"},
+    {file = "psutil-5.8.0-cp39-cp39-win_amd64.whl", hash = "sha256:f4634b033faf0d968bb9220dd1c793b897ab7f1189956e1aa9eae752527127d3"},
+    {file = "psutil-5.8.0.tar.gz", hash = "sha256:0c9ccb99ab76025f2f0bbecf341d4656e9c1351db8cc8a03ccd62e318ab4b5c6"},
 ]
 python-dateutil = [
     {file = "python-dateutil-2.8.1.tar.gz", hash = "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c"},
@@ -302,9 +389,17 @@ six = [
     {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},
     {file = "six-1.15.0.tar.gz", hash = "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259"},
 ]
+taskipy = [
+    {file = "taskipy-1.8.1-py3-none-any.whl", hash = "sha256:2b98f499966e40175d1f1306a64587f49dfa41b90d0d86c8f28b067cc58d0a56"},
+    {file = "taskipy-1.8.1.tar.gz", hash = "sha256:7a2404125817e45d80e13fa663cae35da6e8ba590230094e815633653e25f98f"},
+]
 text-unidecode = [
     {file = "text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93"},
     {file = "text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8"},
+]
+toml = [
+    {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
+    {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
 ]
 typing-extensions = [
     {file = "typing_extensions-3.7.4.3-py2-none-any.whl", hash = "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cookiecutter-jira-project"
-version = "0.1.0"
+version = "0.1.1"
 description = "A cookiecutter template for managing jira projects locally"
 authors = ["Conor Sheehan <conor.sheehan.dev@gmail.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,10 @@ cookiecutter = "^1.7.2"
 
 [tool.poetry.dev-dependencies]
 bump2version = "^1.0.1"
+taskipy = "^1.8.1"
+
+[tool.taskipy.tasks]
+tests = "bats $(find ./tests -name '*.bats' | sort)"
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -127,7 +127,7 @@ setup() {
             rm -rf "$example_dir"
         fi
         # setup example project so utils.sh exists and can be tested
-        poetry run cookiecutter . --overwrite-if-exists --no-input base_dir="$PWD"
+        poetry run cookiecutter . --overwrite-if-exists --no-input base_dir="$PWD" editor="echo"
     fi
 
     # load functions to be tested

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -94,6 +94,79 @@ assert() {
     fi
 }
 
+# https://github.com/ztombol/bats-file/blob/master/src/file.bash
+# bats-file - Common filesystem assertions and helpers for Bats
+#
+# Written in 2016 by Zoltan Tombol <zoltan dot tombol at gmail dot com>
+#
+# To the extent possible under law, the author(s) have dedicated all
+# copyright and related and neighboring rights to this software to the
+# public domain worldwide. This software is distributed without any
+# warranty.
+#
+# You should have received a copy of the CC0 Public Domain Dedication
+# along with this software. If not, see
+# <http://creativecommons.org/publicdomain/zero/1.0/>.
+#
+
+#
+# file.bash
+# ---------
+#
+# Assertions are functions that perform a test and output relevant
+# information on failure to help debugging. They return 1 on failure
+# and 0 otherwise.
+#
+# All output is formatted for readability using the functions of
+# `output.bash' and sent to the standard error.
+#
+
+# Fail and display path of the file (or directory) if it does not exist.
+# This function is the logical complement of `assert_file_not_exist'.
+#
+# Globals:
+#   BATSLIB_FILE_PATH_REM
+#   BATSLIB_FILE_PATH_ADD
+# Arguments:
+#   $1 - path
+# Returns:
+#   0 - file exists
+#   1 - otherwise
+# Outputs:
+#   STDERR - details, on failure
+assert_file_exist() {
+    local -r file="$1"
+    if [[ ! -e "$file" ]]; then
+        local -r rem="$BATSLIB_FILE_PATH_REM"
+        local -r add="$BATSLIB_FILE_PATH_ADD"
+        flunk "$1 does not exist"
+    fi
+}
+
+# Fail and display path of the file (or directory) if it exists. This
+# function is the logical complement of `assert_file_exist'.
+#
+# Globals:
+#   BATSLIB_FILE_PATH_REM
+#   BATSLIB_FILE_PATH_ADD
+# Arguments:
+#   $1 - path
+# Returns:
+#   0 - file does not exist
+#   1 - otherwise
+# Outputs:
+#   STDERR - details, on failure
+assert_file_not_exist() {
+    local -r file="$1"
+    if [[ -e "$file" ]]; then
+        local -r rem="$BATSLIB_FILE_PATH_REM"
+        local -r add="$BATSLIB_FILE_PATH_ADD"
+        flunk "$1 exists, but it was expected to be absent"
+    fi
+}
+
+##############################
+# custom setup and teardown
 setup_example_files() {
     # make temp directory and example files
     target_dir=$(mktemp -d '/tmp/examples_XXX')
@@ -116,27 +189,52 @@ run_relative() {
     run bash -c "${BATS_TEST_DIRNAME}/../$1"
 }
 
+
+project_dir="alphabet"
+repo_dir="$PWD/$project_dir/repo"
+
+cleanup() {
+    # handle case where teardown doesn't run because of unhandled failure
+    # check if dir already exists, if it does delete it
+    if [ -d "$project_dir" ]; then
+        rm -rf "$project_dir"
+    fi
+}
+
 # https://github.com/bats-core/bats-core/issues/39#issuecomment-377015447
 setup() {
-    example_dir="alphabet"
-
     # only run before first test
     if [[ "$BATS_TEST_NUMBER" -eq 1 ]]; then
-        # check if dir already exists, if it does delete it
-        if [ -d "$example_dir" ]; then
-            rm -rf "$example_dir"
-        fi
+        cleanup
+
         # setup example project so utils.sh exists and can be tested
-        poetry run cookiecutter . --overwrite-if-exists --no-input base_dir="$PWD" editor="echo"
+        # stub editor by using echo instead
+        poetry run cookiecutter . \
+            --overwrite-if-exists \
+            --no-input \
+            base_dir="$PWD" \
+            repo_dir="$repo_dir" \
+            editor="echo"
+
+        # setup example repo
+        mkdir "$repo_dir"
+        git init "$repo_dir"
+        # TODO: use local filesystem as fake remote, using this repo on github for now since it only pulls, never push.
+        # https://stackoverflow.com/questions/10603671/how-to-add-a-local-repo-and-treat-it-as-a-remote-repo
+        # git -C "$repo_dir/.git" remote add origin "$fake_remote/.git"
+        # https://stackoverflow.com/a/35899275/6305204
+        git -C "$repo_dir" remote add origin "https://github.com/ConorSheehan1/cookiecutter-jira-project"
+        git -C "$repo_dir" fetch
+        git -C "$repo_dir" checkout master
+        # git branch --set-upstream-to=origin/master master
     fi
 
     # load functions to be tested
-    load "$example_dir/utils.sh"
+    load "$project_dir/utils.sh"
 }
 
-# teardown() {
-#     if [[ "${#BATS_TEST_NAMES[@]}" -eq "$BATS_TEST_NUMBER" ]]; then
-#         # TODO: fix teardown, failing multiple runs
-#         rm -rf "../alphabet"
-#     fi
-# }
+teardown() {
+    if [[ "${#BATS_TEST_NAMES[@]}" -eq "$BATS_TEST_NUMBER" ]]; then
+        cleanup
+    fi
+}

--- a/tests/utils.bats
+++ b/tests/utils.bats
@@ -1,6 +1,5 @@
 #!/usr/bin/env bats
 
-# must run `poetry run cookiecutter . --overwrite-if-exists --no-input base_dir="$PWD"` first
 load "test_helper"
 
 @test "goto_alphabet_issues" {
@@ -8,9 +7,49 @@ load "test_helper"
   assert_equal "$PWD" "$alphabet_issue_dir"
 }
 
-# TODO: either stub code or add option to skip it un utils.sh
 @test "alphabet_new_retro" {
+  # only the template exists
   assert_equal '1' $(ls $alphabet_retro_dir | wc -l)
+
   alphabet_new_retro
+  # the template and the new retro exists
   assert_equal '2' $(ls $alphabet_retro_dir | wc -l)
 }
+
+@test "alphabet_new_issue_fail_regex" {
+  # only issue_log exists
+  assert_equal '1' $(ls $alphabet_issue_dir | wc -l)
+
+  # need run to assert failure
+  run alphabet_new_issue "asdf"
+
+  assert_output "asdf must match ^ABC-([0-9]+)(.*)+"
+
+  # no issue created, only issue_log exists
+  assert_equal '1' $(ls $alphabet_issue_dir | wc -l)
+  assert_failure
+}
+
+@test "alphabet_new_issue" {
+  # only issue_log exists
+  assert_equal '1' $(ls $alphabet_issue_dir | wc -l)
+
+  alphabet_new_issue "ABC-123"
+
+  # should be on new branch
+  assert_equal "ABC-123" $(git -C $alphabet_repo_dir symbolic-ref --short HEAD)
+
+  # should create tech design file
+  assert_file_exist "$alphabet_issue_dir/ABC-123/tech.md"
+
+  # should have exactly 2 directories in issues, the template and the new issue (ABC-123)
+  assert_equal '2' $(ls $alphabet_issue_dir | wc -l)
+}
+
+# @test "alphabet_new_issue_stash" {
+#   touch "$alphabet_repo_dir/asdf"
+
+#   alphabet_new_issue "ABC-223"
+#   # should have stashed changes if they exist
+#   assert_equal "stash@{0}: pre ABC-223asdf" $(git -C $alphabet_repo_dir --no-pager stash list -1)
+# }

--- a/tests/utils.bats
+++ b/tests/utils.bats
@@ -13,16 +13,17 @@ load "test_helper"
 
 @test "alphabet_new_retro" {
   # only the template exists
-  assert_equal '1' "$(ls $alphabet_retro_dir | wc -l)"
+  # pipe to xargs to trim spaces (on osx)
+  assert_equal '1' "$(ls $alphabet_retro_dir | wc -l | xargs)"
 
   alphabet_new_retro
   # the template and the new retro exists
-  assert_equal '2' "$(ls $alphabet_retro_dir | wc -l)"
+  assert_equal '2' "$(ls $alphabet_retro_dir | wc -l | xargs)"
 }
 
 @test "alphabet_new_issue_fail_regex" {
   # only issue_log exists
-  assert_equal '1' "$(ls $alphabet_issue_dir | wc -l)"
+  assert_equal '1' "$(ls $alphabet_issue_dir | wc -l | xargs)"
 
   # need run to assert failure
   run alphabet_new_issue "asdf"
@@ -30,13 +31,13 @@ load "test_helper"
   assert_output "asdf must match ^ABC-([0-9]+)(.*)+"
 
   # no issue created, only issue_log exists
-  assert_equal '1' "$(ls $alphabet_issue_dir | wc -l)"
+  assert_equal '1' "$(ls $alphabet_issue_dir | wc -l | xargs)"
   assert_failure
 }
 
 @test "alphabet_new_issue" {
   # only issue_log exists
-  assert_equal '1' "$(ls $alphabet_issue_dir | wc -l)"
+  assert_equal '1' "$(ls $alphabet_issue_dir | wc -l | xargs)"
 
   alphabet_new_issue "ABC-123"
 
@@ -47,7 +48,7 @@ load "test_helper"
   assert_file_exist "$alphabet_issue_dir/ABC-123/tech.md"
 
   # should have exactly 2 directories in issues, the template and the new issue (ABC-123)
-  assert_equal '2' "$(ls $alphabet_issue_dir | wc -l)"
+  assert_equal '2' "$(ls $alphabet_issue_dir | wc -l | xargs)"
 }
 
 @test "goto_current_issue" {

--- a/tests/utils.bats
+++ b/tests/utils.bats
@@ -9,8 +9,8 @@ load "test_helper"
 }
 
 # TODO: either stub code or add option to skip it un utils.sh
-# @test "alphabet_new_retro" {
-#   assert_equal '1' $(ls $alphabet_retro_dir | wc -l)
-#   alphabet_new_retro
-#   assert_equal '2' $(ls $alphabet_retro_dir | wc -l)
-# }
+@test "alphabet_new_retro" {
+  assert_equal '1' $(ls $alphabet_retro_dir | wc -l)
+  alphabet_new_retro
+  assert_equal '2' $(ls $alphabet_retro_dir | wc -l)
+}

--- a/tests/utils.bats
+++ b/tests/utils.bats
@@ -2,23 +2,27 @@
 
 load "test_helper"
 
+# TODO:
+# 1. test date in retro filename, freeze date?
+# 2. test issue log
+
 @test "goto_alphabet_issues" {
   goto_alphabet_issues
-  assert_equal "$PWD" "$alphabet_issue_dir"
+  assert_equal "$alphabet_issue_dir" "$PWD"
 }
 
 @test "alphabet_new_retro" {
   # only the template exists
-  assert_equal '1' $(ls $alphabet_retro_dir | wc -l)
+  assert_equal '1' "$(ls $alphabet_retro_dir | wc -l)"
 
   alphabet_new_retro
   # the template and the new retro exists
-  assert_equal '2' $(ls $alphabet_retro_dir | wc -l)
+  assert_equal '2' "$(ls $alphabet_retro_dir | wc -l)"
 }
 
 @test "alphabet_new_issue_fail_regex" {
   # only issue_log exists
-  assert_equal '1' $(ls $alphabet_issue_dir | wc -l)
+  assert_equal '1' "$(ls $alphabet_issue_dir | wc -l)"
 
   # need run to assert failure
   run alphabet_new_issue "asdf"
@@ -26,30 +30,45 @@ load "test_helper"
   assert_output "asdf must match ^ABC-([0-9]+)(.*)+"
 
   # no issue created, only issue_log exists
-  assert_equal '1' $(ls $alphabet_issue_dir | wc -l)
+  assert_equal '1' "$(ls $alphabet_issue_dir | wc -l)"
   assert_failure
 }
 
 @test "alphabet_new_issue" {
   # only issue_log exists
-  assert_equal '1' $(ls $alphabet_issue_dir | wc -l)
+  assert_equal '1' "$(ls $alphabet_issue_dir | wc -l)"
 
   alphabet_new_issue "ABC-123"
 
   # should be on new branch
-  assert_equal "ABC-123" $(git -C $alphabet_repo_dir symbolic-ref --short HEAD)
+  assert_equal "ABC-123" "$(git -C $alphabet_repo_dir symbolic-ref --short HEAD)"
 
   # should create tech design file
   assert_file_exist "$alphabet_issue_dir/ABC-123/tech.md"
 
   # should have exactly 2 directories in issues, the template and the new issue (ABC-123)
-  assert_equal '2' $(ls $alphabet_issue_dir | wc -l)
+  assert_equal '2' "$(ls $alphabet_issue_dir | wc -l)"
 }
 
-# @test "alphabet_new_issue_stash" {
-#   touch "$alphabet_repo_dir/asdf"
+@test "goto_current_issue" {
+  alphabet_new_issue "ABC-222"
+  goto_alphabet_current_issue
 
-#   alphabet_new_issue "ABC-223"
-#   # should have stashed changes if they exist
-#   assert_equal "stash@{0}: pre ABC-223asdf" $(git -C $alphabet_repo_dir --no-pager stash list -1)
-# }
+  assert_equal "$alphabet_issue_dir/ABC-222" "$PWD"
+}
+
+@test "current_issue" {
+  alphabet_new_issue "ABC-001-cat"
+
+  assert_equal "ABC-001-cat" "$(alphabet_current_issue)"
+}
+
+@test "alphabet_new_issue_stash" {
+  touch "$alphabet_repo_dir/asdf"
+  git -C "$alphabet_repo_dir" add "$alphabet_repo_dir/asdf"
+
+  alphabet_new_issue "ABC-456789"
+
+  # should have stashed changes if they exist
+  assert_equal "stash@{0}: On ABC-001-cat: pre ABC-456789" "$(git --no-pager -C $alphabet_repo_dir stash list -1)"
+}

--- a/{{cookiecutter.project_name|lower}}/retro/retro_template.md
+++ b/{{cookiecutter.project_name|lower}}/retro/retro_template.md
@@ -1,4 +1,4 @@
-<!-- template version 0.1.0 -->
+<!-- template version 0.1.1 -->
 # continue
 
 # start 

--- a/{{cookiecutter.project_name|lower}}/utils.sh
+++ b/{{cookiecutter.project_name|lower}}/utils.sh
@@ -9,12 +9,12 @@
 {{cookiecutter.project_name|lower}}_retro_dir="{{cookiecutter.base_dir}}/{{cookiecutter.project_name|lower}}/retro"
 
 goto_{{cookiecutter.project_name|lower}}_issues() {
-  cd "${{cookiecutter.project_name|lower}}_issue_dir" || exit
+  cd "${{cookiecutter.project_name|lower}}_issue_dir" || return
 }
 
 goto_{{cookiecutter.project_name|lower}}_current_issue() {
   current_issue=$(tail -n 1 "${{cookiecutter.project_name|lower}}_issue_log")
-  cd "${{cookiecutter.project_name|lower}}_issue_dir/$current_issue" || exit
+  cd "${{cookiecutter.project_name|lower}}_issue_dir/$current_issue" || return
 }
 
 {{cookiecutter.project_name|lower}}_current_issue() {
@@ -33,7 +33,7 @@ goto_{{cookiecutter.project_name|lower}}_current_issue() {
   new_issue_tech_design="$new_issue_dir/tech.md"
 
   echo "$1" >> "${{cookiecutter.project_name|lower}}_issue_log"
-  cd "${{cookiecutter.project_name|lower}}_repo_dir" || exit
+  cd "${{cookiecutter.project_name|lower}}_repo_dir" || return
   git stash save "pre $1"
   git checkout master
   git pull

--- a/{{cookiecutter.project_name|lower}}/utils.sh
+++ b/{{cookiecutter.project_name|lower}}/utils.sh
@@ -9,12 +9,12 @@
 {{cookiecutter.project_name|lower}}_retro_dir="{{cookiecutter.base_dir}}/{{cookiecutter.project_name|lower}}/retro"
 
 goto_{{cookiecutter.project_name|lower}}_issues() {
-  cd "${{cookiecutter.project_name|lower}}_issue_dir" || return
+  cd "${{cookiecutter.project_name|lower}}_issue_dir" || return 1
 }
 
 goto_{{cookiecutter.project_name|lower}}_current_issue() {
   current_issue=$(tail -n 1 "${{cookiecutter.project_name|lower}}_issue_log")
-  cd "${{cookiecutter.project_name|lower}}_issue_dir/$current_issue" || return
+  cd "${{cookiecutter.project_name|lower}}_issue_dir/$current_issue" || return 1
 }
 
 {{cookiecutter.project_name|lower}}_current_issue() {
@@ -33,11 +33,11 @@ goto_{{cookiecutter.project_name|lower}}_current_issue() {
   new_issue_tech_design="$new_issue_dir/tech.md"
 
   echo "$1" >> "${{cookiecutter.project_name|lower}}_issue_log"
-  cd "${{cookiecutter.project_name|lower}}_repo_dir" || return
-  git stash save "pre $1"
-  git checkout master
-  git pull
-  git checkout -b "$1"
+  cd "${{cookiecutter.project_name|lower}}_repo_dir" || return 1
+  git -C "${{cookiecutter.project_name|lower}}_repo_dir" stash save "pre $1"
+  git -C "${{cookiecutter.project_name|lower}}_repo_dir" checkout master
+  git -C "${{cookiecutter.project_name|lower}}_repo_dir" pull
+  git -C "${{cookiecutter.project_name|lower}}_repo_dir" checkout -b "$1"
   echo making "$new_issue_dir"
   mkdir "$new_issue_dir"
   mkdir "$new_issue_dir/screenshots"

--- a/{{cookiecutter.project_name|lower}}/utils.sh
+++ b/{{cookiecutter.project_name|lower}}/utils.sh
@@ -8,6 +8,8 @@
 {{cookiecutter.project_name|lower}}_issue_log="${{cookiecutter.project_name|lower}}_issue_dir/issue_log"
 {{cookiecutter.project_name|lower}}_retro_dir="{{cookiecutter.base_dir}}/{{cookiecutter.project_name|lower}}/retro"
 
+code_editor="${VISUAL:-${EDITOR:-{{cookiecutter.editor}}}}"
+
 goto_{{cookiecutter.project_name|lower}}_issues() {
   cd "${{cookiecutter.project_name|lower}}_issue_dir" || exit
 }
@@ -43,7 +45,7 @@ goto_{{cookiecutter.project_name|lower}}_current_issue() {
   mkdir "$new_issue_dir/screenshots"
   touch "$new_issue_tech_design"
   # open dir to see all files too
-  code "$new_issue_dir" "$new_issue_tech_design"
+  $code_editor "$new_issue_dir" "$new_issue_tech_design"
 }
 
 {{cookiecutter.project_name|lower}}_new_retro() {
@@ -59,5 +61,5 @@ goto_{{cookiecutter.project_name|lower}}_current_issue() {
   fi
   cp "$retro_template" "$new_retro"
   # open dir to see all files too
-  code "${{cookiecutter.project_name|lower}}_retro_dir" "$new_retro"
+  $code_editor "${{cookiecutter.project_name|lower}}_retro_dir" "$new_retro"
 }

--- a/{{cookiecutter.project_name|lower}}/utils.sh
+++ b/{{cookiecutter.project_name|lower}}/utils.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# template version 0.1.0
+# template version 0.1.1
 
 {{cookiecutter.project_name|lower}}_repo_dir="{{cookiecutter.repo_dir}}"
 # TODO: get basedir instead of passing in as arg

--- a/{{cookiecutter.project_name|lower}}/utils.sh
+++ b/{{cookiecutter.project_name|lower}}/utils.sh
@@ -8,8 +8,6 @@
 {{cookiecutter.project_name|lower}}_issue_log="${{cookiecutter.project_name|lower}}_issue_dir/issue_log"
 {{cookiecutter.project_name|lower}}_retro_dir="{{cookiecutter.base_dir}}/{{cookiecutter.project_name|lower}}/retro"
 
-code_editor="${VISUAL:-${EDITOR:-{{cookiecutter.editor}}}}"
-
 goto_{{cookiecutter.project_name|lower}}_issues() {
   cd "${{cookiecutter.project_name|lower}}_issue_dir" || exit
 }
@@ -45,7 +43,7 @@ goto_{{cookiecutter.project_name|lower}}_current_issue() {
   mkdir "$new_issue_dir/screenshots"
   touch "$new_issue_tech_design"
   # open dir to see all files too
-  $code_editor "$new_issue_dir" "$new_issue_tech_design"
+  {{cookiecutter.editor}} "$new_issue_dir" "$new_issue_tech_design"
 }
 
 {{cookiecutter.project_name|lower}}_new_retro() {
@@ -61,5 +59,5 @@ goto_{{cookiecutter.project_name|lower}}_current_issue() {
   fi
   cp "$retro_template" "$new_retro"
   # open dir to see all files too
-  $code_editor "${{cookiecutter.project_name|lower}}_retro_dir" "$new_retro"
+  {{cookiecutter.editor}} "${{cookiecutter.project_name|lower}}_retro_dir" "$new_retro"
 }


### PR DESCRIPTION
1. make editor configurable instead of opening with vscode
2. `return 1` instead of `exit` on failure in `utils.sh` to avoid closing shell
3. add notes on debugging bats
4. add bats file helpers from https://github.com/ztombol/bats-file/blob/master/src/file.bash
5. use `git -C` to ensure commands are run in correct dir
6. moar tests
7. bump template patch version